### PR TITLE
Calculate circularity of each grain and add to the statistics

### DIFF
--- a/src/perovstats/classes.py
+++ b/src/perovstats/classes.py
@@ -12,12 +12,15 @@ class Grain:
     ----------
     grain_id : int | None
         Unique identifier for the grain.
+    grain_mask : np.ndarray | None
+        A binary mask of the outline of the singular grain.
     grain_area : float | None
         Area of the grain in nm^2.
     grain_circularity_rating : float | None
         Unifinished var.
     """
     grain_id: int
+    grain_mask: np.ndarray | None = None
     grain_area: float | None = None
     grain_circularity_rating: float | None = None
 

--- a/src/perovstats/default_config.yaml
+++ b/src/perovstats/default_config.yaml
@@ -33,11 +33,10 @@ freqsplit:
   min_rms: 12 # Minimum roughness mean score of a high-pass after splitting along the cutoff.
 mask:
   threshold_function: mad # Options: std, mad.
-  threshold_bounds: [0, 3] # Minimum and maximum thresholds for masking.
-  threshold_step: 0.05 # Amount to increase the tested threshold by each iteration.
+  threshold_bounds: [0, 4] # Minimum and maximum thresholds for masking.
   smoothing:
     smooth_function: gaussian # Options: gaussian, difference_of_gaussians.
     sigma: 8
   cleaning:
-    area_threshold: 10000 # in nm2
+    area_threshold: 10000 # in nm2.
     disk_radius_factor: 40

--- a/src/perovstats/fourier.py
+++ b/src/perovstats/fourier.py
@@ -33,7 +33,6 @@ def create_masks(config, image_object) -> None:
             threshold_func = threshold_mean_std
         min_threshold = config["mask"]["threshold_bounds"][0]
         max_threshold = config["mask"]["threshold_bounds"][1]
-        threshold_step = config["mask"]["threshold_step"]
 
         # Cleaning config options
         area_threshold = config["mask"]["cleaning"]["area_threshold"]
@@ -64,7 +63,6 @@ def create_masks(config, image_object) -> None:
             pixel_to_nm_scaling=pixel_to_nm_scaling,
             min_threshold=min_threshold,
             max_threshold=max_threshold,
-            threshold_step=threshold_step,
         )
         if threshold is None:
             return
@@ -193,18 +191,17 @@ def normalise_array(arr):
 
 
 def find_threshold(
-        filename: str,
-        image: np.ndarray,
-        threshold_func: callable,
-        smooth_sigma: float,
-        smooth_func,
-        area_threshold,
-        disk_radius,
-        pixel_to_nm_scaling,
-        min_threshold,
-        max_threshold,
-        threshold_step,
-    ):
+    filename: str,
+    image: np.ndarray,
+    threshold_func: callable,
+    smooth_sigma: float,
+    smooth_func,
+    area_threshold,
+    disk_radius,
+    pixel_to_nm_scaling,
+    min_threshold,
+    max_threshold,
+):
     """
     Loop through possible threshold values and select the value
     that produces the most grains.
@@ -237,6 +234,7 @@ def find_threshold(
 
     best_threshold = None
     best_grain_num = 0
+    threshold_step = (max_threshold - min_threshold) / 50
     for curr_threshold in np.arange(min_threshold, max_threshold, threshold_step):
         curr_threshold = round(curr_threshold, 3)
         np_mask = create_grain_mask(


### PR DESCRIPTION
Closes #5 

Each grain found is given a circularity rating of 0 to 1 based on a normalised isoperimetric quotient of the mask - a perfect circle always giving a 1, reducing the further away a mask is from a circular shape. This value is added to the statistics for that grain (and saved to the relative CSV file).

More robust testing is required but this seems to be a good and simple starting point for this value.