### PR TITLE
Simplified loguru message syntax for cleaner look

### DIFF
--- a/src/perovstats/cli.py
+++ b/src/perovstats/cli.py
@@ -142,7 +142,16 @@ def get_arg(key: str, args: Namespace, config: dict, default: str | None = None)
 
 
 def setup_logger():
+    import pprint
+    logger.remove()
     logger.add("logs/PerovStats-{time:YYYY-MM-DD-HH-mm-ss}.log", level="DEBUG")
+    logger.add(sys.stdout,
+               level="DEBUG",
+               format="<blue>{time:HH:mm:ss}</blue> | <level>{level}</level> | <magenta>{file}</magenta> | {message}",
+               colorize=True)
+
+    pprint.pprint(logger._core.handlers)
+
 
 @logger.catch
 def main(args: list[str] | None = None) -> None:
@@ -203,7 +212,7 @@ def main(args: list[str] | None = None) -> None:
 
     logger.info(f"Loaded {len(perovstats_object.images)} images")
 
-    for image_num, image_object in enumerate(perovstats_object.images):
+    for image_object in perovstats_object.images:
         logger.info("----------------------------------------------------------")
         logger.info(f"processing {image_object.filename}")
         logger.info("----------------------------------------------------------")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ def dummy_grain_object(dummy_grain_mask) -> Grain:
 def dummy_image_data_object(dummy_mask, dummy_high_pass, dummy_low_pass, dummy_original_image, dummy_grain_object, tmp_path) -> ImageData:
     image_data = ImageData(
         image_original=dummy_original_image,
+        image_flattened=None,
         mask=dummy_mask,
         high_pass=dummy_high_pass,
         low_pass=dummy_low_pass,


### PR DESCRIPTION
Previously the file that a log message comes from was repeated twice in the log message which was unnecessary. This has been removed by setting up a custom log prefix for all logs. Nothing else was changed, this is the new syntax:
`time(HH:mm:ss) | log level | file.py | [current image] : message`